### PR TITLE
Fix type error

### DIFF
--- a/short_desc.py
+++ b/short_desc.py
@@ -435,7 +435,7 @@ class ShortDescription:
 			cl = i.getClaimsForProperty(1082)
 			best = self.getBestQuantity(cl)
 			label = self.wd.getItem('P1082').getLabel()
-			h.append(', ' + label + ' ' + best)
+			h.append(f', {label} {best}')
 
 		# Creator etc.
 		self.add2desc(h, item_labels, [175, 86, 170, 57, 50, 61, 176], {"txt_key": 'by', "o": opt})


### PR DESCRIPTION
Seems to be triggered on items with P1082 (population), e.g. https://autodesc.toolforge.org/?q=Q974345

```
    h.append(', ' + label + ' ' + best)                  
TypeError: can only concatenate str (not "float") to str 
```

Fix produces "City of the United States, population 15133.0, from 1933".